### PR TITLE
build(nix): run the app from the flake, not just the tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,13 +12,19 @@ uv run pytest
 
 ```bash
 nix flake check   # 57 unit tests, hermetic; e2e skip
-nix develop       # shell with python 3.13 + deps + uv; then: pytest
+nix develop       # python 3.13 + every dep + pytest + uv; then: pytest
+nix run .#        # the GUI, after `nix run .# -- setup`
 ```
 
 `nix flake check` is a real gate — it exits non-zero on a failing test. It runs
-the unit tests only, because `kokoro-onnx` and `espeakng-loader` are not
-packaged in nixpkgs and the e2e tests need the downloaded models regardless.
-Reach for `uv` inside `nix develop` when you need the synthesiser.
+the unit tests only, because a build sandbox should not download 870 MB of
+models; run `pytest` inside `nix develop` after `setup` to get all 65.
+
+`kokoro-onnx`, `phonemizer-fork` and `espeakng-loader` are not in nixpkgs, so
+the flake builds them. `espeakng-loader` is a shim over nixpkgs' `espeak-ng`
+instead of the vendored library in the upstream wheel — if you bump it, keep
+`get_library_path()` and `get_data_path()` as the only API, since that is all
+`stts.tts` calls.
 
 ## Ground rules
 

--- a/README.md
+++ b/README.md
@@ -153,18 +153,34 @@ uv run stts            # open the GUI
 uv run pytest          # 65 tests
 ```
 
-With Nix, `nix flake check` runs the 57 unit tests hermetically, and
-`nix develop` gives a shell where `pytest` works without `uv sync`:
+### With Nix
+
+The flake covers the whole thing — running the app included, not just the tests:
 
 ```bash
-nix flake check   # 57 passed, 8 skipped
-nix develop       # then: pytest
+nix flake check         # 57 unit tests, hermetic, exits non-zero on failure
+nix run .# -- doctor    # check the environment
+nix run .# -- setup     # download the ~870 MB of models
+nix run .#              # open the GUI
+nix develop             # same deps + pytest + uv, for hacking
 ```
 
-The flake pins Python 3.13 (pyproject caps at `<3.14`). It cannot cover the e2e
-tests: `kokoro-onnx` and `espeakng-loader` are not in nixpkgs, and those tests
-need the models anyway — use the `uv` route above for that. `uv` is on the
-`nix develop` PATH for exactly that purpose.
+It pins Python 3.13 to match `.python-version`. `kokoro-onnx`, `phonemizer-fork`
+and `espeakng-loader` are not in nixpkgs, so the flake builds them: the first
+two from their PyPI wheels, and `espeakng-loader` as a shim pointing at
+nixpkgs' `espeak-ng` rather than the vendored binary in the upstream wheel.
+
+`nix flake check` deliberately runs only the unit tests — a build sandbox has no
+business downloading 870 MB. Once `setup` has run, `nix develop` then `pytest`
+executes all 65.
+
+### Running it on Linux
+
+It works, with one gap: the virtual-microphone helper is Windows-only
+(VB-CABLE). To feed OBS or Discord on Linux, make a PipeWire null sink and
+select it as the output device — the app says as much if you click the button.
+Everything else (capture, recognition, synthesis, monitoring) is
+platform-independent. `stts devices` lists what it can see.
 
 Other commands: `stts doctor` (environment check), `stts devices` (list audio
 devices), `stts bench [--gpu]` (measure recogniser and synthesiser latency).

--- a/flake.nix
+++ b/flake.nix
@@ -18,22 +18,123 @@
       # Do not "fix" this to 3.12: nixpkgs has no cached onnxruntime for 3.12,
       # so that build pulls protobuf, eigen and a Rust toolchain from source.
       #
-      # kokoro-onnx and espeakng-loader are absent from nixpkgs, so the
-      # synthesiser is not importable from this environment. It does not have
-      # to be: stts.tts imports them lazily inside Synthesiser._load(), so
-      # every unit test collects and runs, and the e2e tests skip on their
-      # models fixture. See the devShell for the uv-based route that does get
-      # the synthesiser.
-      pythonFor = pkgs: pkgs.python313.withPackages (ps: [
-        ps.numpy # everywhere
-        ps.scipy # audio/resample.py
-        ps.onnxruntime # vad.py, runtime.py
-        ps.sounddevice # audio/capture.py, audio/playback.py (lazy)
-        ps.onnx-asr # stt.py (lazy)
-        ps.huggingface-hub # models.py (lazy) -- the [hub] extra
-        ps.pytest
-        ps.pytest-timeout # pyproject sets timeout = 600
-      ]);
+      # The synthesiser's three dependencies that nixpkgs does not carry.
+      # Building them here is what makes the app runnable from nix rather than
+      # test-only: without kokoro-onnx there is no Synthesiser, and without a
+      # Synthesiser there is no output voice.
+      synthDeps = pkgs: ps: rec {
+        # Upstream ships a vendored libespeak-ng inside a manylinux wheel.
+        # Rather than patchelf a foreign binary, point the same two-function
+        # API at the espeak-ng nixpkgs already builds. stts.tts only ever calls
+        # get_library_path() and get_data_path().
+        espeakng-loader = ps.buildPythonPackage {
+          pname = "espeakng-loader";
+          version = "0.2.4-nixpkgs-espeak";
+          format = "other";
+          dontUnpack = true;
+          installPhase = ''
+            mkdir -p "$out/${ps.python.sitePackages}"
+
+            # Real dist-info, so kokoro-onnx's declared dependency on
+            # espeakng-loader is genuinely satisfied rather than suppressed.
+            dist="$out/${ps.python.sitePackages}/espeakng_loader-0.2.4.dist-info"
+            mkdir -p "$dist"
+            cat > "$dist/METADATA" <<'META'
+            Metadata-Version: 2.1
+            Name: espeakng-loader
+            Version: 0.2.4
+            Summary: Locate espeak-ng's shared library and data directory.
+            META
+            echo "Wheel-Version: 1.0" > "$dist/WHEEL"
+            echo "espeakng_loader" > "$dist/top_level.txt"
+            : > "$dist/RECORD"
+
+            cat > "$out/${ps.python.sitePackages}/espeakng_loader.py" <<EOF
+            """Shim: serve nixpkgs' espeak-ng instead of a vendored copy."""
+            from pathlib import Path
+
+            _PREFIX = Path("${pkgs.espeak-ng}")
+
+
+            def get_library_path() -> Path:
+                return _PREFIX / "lib" / "libespeak-ng${pkgs.stdenv.hostPlatform.extensions.sharedLibrary}"
+
+
+            def get_data_path() -> Path:
+                return _PREFIX / "share" / "espeak-ng-data"
+            EOF
+          '';
+        };
+
+        phonemizer-fork = ps.buildPythonPackage rec {
+          pname = "phonemizer_fork";
+          version = "3.3.2";
+          format = "wheel";
+          src = pkgs.fetchurl {
+            url = "https://files.pythonhosted.org/packages/64/f1/0dcce21b0ae16a82df4b6583f8f3ad8e55b35f7e98b6bf536a4dd225fa08/${pname}-${version}-py3-none-any.whl";
+            hash = "sha256-lzBcdvQYOzgl2uj0wDImX+eMmUbOWMR9S2IWE0kmS3Q=";
+          };
+          propagatedBuildInputs = [ ps.attrs ps.dlinfo ps.joblib ps.segments ps.typing-extensions ];
+          doCheck = false;
+          pythonImportsCheck = [ "phonemizer" ];
+        };
+
+        kokoro-onnx = ps.buildPythonPackage rec {
+          pname = "kokoro_onnx";
+          version = "0.5.0";
+          format = "wheel";
+          src = pkgs.fetchurl {
+            url = "https://files.pythonhosted.org/packages/0d/55/0bfcb4aa50033c89e5ac132af3d07fac0543824ce6eaefd4d1bfdcc3795b/${pname}-${version}-py3-none-any.whl";
+            hash = "sha256-Thw4opbbXbwfci9p9ePBPy4od7PlsUUof1bsBXAT41c=";
+          };
+          propagatedBuildInputs = [ ps.numpy ps.onnxruntime espeakng-loader phonemizer-fork ];
+          doCheck = false;
+          pythonImportsCheck = [ "kokoro_onnx" ];
+        };
+      };
+
+      pythonFor = pkgs: pkgs.python313.withPackages (ps:
+        let extra = synthDeps pkgs ps; in [
+          ps.numpy # everywhere
+          ps.scipy # audio/resample.py
+          ps.onnxruntime # vad.py, runtime.py
+          ps.sounddevice # audio/capture.py, audio/playback.py (lazy)
+          ps.onnx-asr # stt.py (lazy)
+          ps.huggingface-hub # models.py (lazy) -- the [hub] extra
+          ps.tkinter # gui.py
+          extra.kokoro-onnx # tts.py -- pulls the other two
+          ps.pytest
+          ps.pytest-timeout # pyproject sets timeout = 600
+        ]);
+
+      # The application itself, so `nix run` does not depend on the working
+      # directory happening to be the source tree.
+      sttsFor = pkgs:
+        let
+          ps = pkgs.python313Packages;
+          extra = synthDeps pkgs ps;
+        in
+        ps.buildPythonApplication {
+          pname = "speech-to-text-to-speech";
+          version = "2.0.0";
+          pyproject = true;
+          src = self;
+          build-system = [ ps.hatchling ];
+          dependencies = [
+            ps.numpy
+            ps.scipy
+            ps.sounddevice
+            ps.onnx-asr
+            ps.huggingface-hub # the onnx-asr [hub] extra
+            ps.onnxruntime
+            ps.tkinter # gui.py
+            extra.kokoro-onnx
+          ];
+          # The suite is the `checks` output; running it here too would make
+          # every `nix run` wait on it.
+          doCheck = false;
+          pythonImportsCheck = [ "stts" "stts.gui" "stts.pipeline" ];
+        };
     in
     {
       # `nix flake check`, or `nix build .#checks.<system>.unit-tests`
@@ -70,29 +171,44 @@
           '';
       });
 
-      # `nix develop`, then `pytest`.
+      # `nix develop` -- a complete environment: every runtime dependency plus
+      # the test tools, so `stts setup` and the GUI both work, not just pytest.
       #
-      # uv is here for the one thing nixpkgs cannot cover: kokoro-onnx and
-      # espeakng-loader are not packaged, so the synthesiser -- and with it the
-      # e2e tests -- needs `uv sync --group dev` and `uv run stts setup`.
+      # uv remains available for cross-checking against the locked PyPI
+      # versions, which are not always the ones nixpkgs carries.
       devShells = forAllSystems (pkgs: {
         default = pkgs.mkShell {
           packages = [ (pythonFor pkgs) pkgs.uv ]
             ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [
             pkgs.portaudio # sounddevice dlopens this
-            pkgs.espeak-ng # kokoro-onnx phonemises through it
+            pkgs.espeak-ng # what the espeakng-loader shim above points at
           ];
 
           shellHook = ''
             echo "speech-to-text-to-speech dev shell"
-            echo "  pytest               -- 57 unit tests (e2e skip without models)"
-            echo "  uv sync --group dev  -- add kokoro-onnx for the e2e path"
+            echo "  pytest                    -- 57 unit tests, +8 e2e once models exist"
+            echo "  python -m stts.cli doctor -- check the environment"
+            echo "  python -m stts.cli setup  -- download ~870 MB of models"
+            echo "  python -m stts.cli        -- open the GUI"
             echo
           '';
         };
       });
 
-      # The interpreter plus test dependencies, exposed so CI can reuse it.
-      packages = forAllSystems (pkgs: { default = pythonFor pkgs; });
+      # `nix run` -- the real CLI, installed rather than run out of the source
+      # tree, so it works from any directory. `nix run .# setup` first: without
+      # the models there is nothing to recognise or speak with.
+      apps = forAllSystems (pkgs: {
+        default = {
+          type = "app";
+          program = "${sttsFor pkgs}/bin/stts";
+        };
+      });
+
+      packages = forAllSystems (pkgs: {
+        default = sttsFor pkgs;
+        # The interpreter plus every dependency, exposed so CI can reuse it.
+        pythonEnv = pythonFor pkgs;
+      });
     };
 }


### PR DESCRIPTION
The flake could only run pytest. Two things stopped it from starting the application:

- tkinter was absent, so `import stts.gui` failed outright with ModuleNotFoundError: No module named '_tkinter'.
- kokoro-onnx was absent, and without it there is no Synthesiser and so no output voice at all.

nixpkgs carries neither kokoro-onnx, phonemizer-fork nor espeakng-loader, so the flake builds them. The first two come from their PyPI wheels; both are pure Python and every transitive dependency was already packaged.

espeakng-loader is a shim rather than the upstream wheel. Upstream vendors a libespeak-ng inside a manylinux wheel, which would need autoPatchelf; since stts.tts only ever calls get_library_path() and get_data_path(), pointing those two at the espeak-ng nixpkgs already builds is simpler and uses a properly linked library. It carries real dist-info metadata so kokoro-onnx's declared dependency is satisfied rather than suppressed with dontCheckRuntimeDeps.

The CLI is now a buildPythonApplication, so `nix run` works from any directory. The first attempt wrapped `python -m stts.cli`, which only worked when the working directory happened to be the source tree.

  nix run .# -- doctor / setup / bench
  nix run .#            opens the GUI
  nix develop           adds pytest and uv

Verified: the espeak paths resolve with phontab present, stts.gui imports, `doctor` reports 3 microphones through PipeWire, and `nix run` works from outside the checkout.

With the models present the e2e tests now run under nix too -- worth knowing that test_response_latency_is_under_one_second asserts an absolute 1000 ms and is therefore hardware-dependent: it fails at 4240 ms on a Ryzen 7 PRO 5850U laptop, where `bench` reports recognise 1573 ms and speak 4784 ms against the 190/425 ms recorded on the i7-11700K in ADR 3 and ADR 4.