### PR TITLE
build(nix): run the app from the flake, and start a benchmark table

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,11 @@ instead of the vendored library in the upstream wheel — if you bump it, keep
   best-looking case, and both the README and an ADR repeated it as if it had
   been measured — see [ADR 5](docs/adr/0005-latency-budget.md). Say which tool
   produced a figure and on what hardware, or leave it out.
+- **Record what you measure.** New timings go in
+  [docs/BENCHMARKS.md](docs/BENCHMARKS.md) with the CPU, the onnxruntime source
+  and version, and the execution provider. Performance here varies by more than
+  an order of magnitude between machines, so a number without its context is
+  not usable by anyone else.
 - **Architectural changes need an ADR.** Swapping a model, the inference
   runtime, the latency strategy or the installer means a new file in
   `docs/adr/`. Tuning a default or adding a voice does not.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,13 @@ not end-to-end delay — `bench` runs the recogniser and synthesiser directly an
 skips voice detection, endpointing, streaming and playback. And they are the
 figures recorded in [ADR 3](docs/adr/0003-speech-recognition-model.md) and
 [ADR 4](docs/adr/0004-speech-synthesis-model.md) when those decisions were
-made; re-run `stts bench` to see what your own machine does.
+made.
+
+**Your machine may be far slower, and it matters.** On a Ryzen 7 PRO 5850U
+laptop, synthesis runs at RTF ~1.75 — slower than real time, which means the
+pipeline can never catch up and none of the latency figures above hold. Run
+`stts bench` before trusting them, and add your result to
+[docs/BENCHMARKS.md](docs/BENCHMARKS.md), which collects per-machine numbers.
 
 On accuracy, Parakeet is chosen on its published word error rate, not on a
 measurement here — in our own comparison Whisper base and Parakeet both

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,0 +1,102 @@
+# Benchmarks
+
+Measured latency per machine. This file grows as machines are added; the ADRs
+record the decisions, this records the numbers.
+
+**Every row must say who measured it and on what.** A figure without its
+hardware, its onnxruntime build and its provider is not reproducible, and this
+project has already been burnt once by a latency number nobody could reproduce
+(see [ADR 5](adr/0005-latency-budget.md)).
+
+## How to add a row
+
+```bash
+nix run .# -- bench          # or: uv run stts bench
+nix run .# -- doctor         # for the onnxruntime version and provider list
+```
+
+Record: CPU model, whether it has AVX-512, OS, onnxruntime **source** (nixpkgs
+build or PyPI wheel) and version, the active execution provider, and the
+summary line. `bench` measures the recogniser and synthesiser **in isolation**
+— it does not include voice detection, endpointing, streaming or playback.
+
+## Stage timings
+
+Kokoro-82M fp16 and Parakeet TDT 0.6B v2, CPU execution provider, ONNX Runtime
+left to pick its own thread count (`STTS_THREADS` unset → `intra_op` default).
+
+| Machine | AVX-512 | onnxruntime | Recognise (mean) | Synthesise (mean) | Kokoro RTF | Real-time capable | Source |
+|---|---|---|---|---|---|---|---|
+| Intel i7-11700K, desktop | yes | not recorded | 190 ms | 425 ms | 0.18 | yes | ADR 3 / ADR 4, at decision time — not reproduced since |
+| AMD Ryzen 7 PRO 5850U, laptop (15–28 W) | no | nixpkgs 1.27.1 | 1573 ms | 4784 ms | 1.54–2.07 | **no** | this repo, 2026-08-14, NixOS |
+
+RTF (real-time factor) is synthesis time ÷ audio duration. **Above 1.0 the
+synthesiser is slower than speech**, so the pipeline can never catch up and the
+streaming design in ADR 5 does not hold. Compare machines on RTF rather than on
+absolute milliseconds: the two rows used different sentence lengths.
+
+### Per-sentence detail
+
+**AMD Ryzen 7 PRO 5850U** — `nix run .# -- bench`, 2026-08-14:
+
+| Audio | Synthesise | Recognise | RTF |
+|---|---|---|---|
+| 2.1 s | 4350 ms | 1312 ms | 2.07 |
+| 2.7 s | 4758 ms | 1830 ms | 1.76 |
+| 3.4 s | 5245 ms | 1577 ms | 1.54 |
+| **aggregate** | **4784 ms** | **1573 ms** | **1.75** |
+
+Also emitted, not yet investigated:
+`WARNING phonemizer: words count mismatch on 200.0% of the lines (2/1)`.
+
+**Intel i7-11700K** — from ADR 3 and ADR 4, transcribing Kokoro-rendered speech:
+
+| Audio | Parakeet v2 | Parakeet v2 int8 | Whisper base |
+|---|---|---|---|
+| 2.4 s | 190 ms | 181 ms | 596 ms |
+| 2.9 s | 190 ms | 202 ms | 623 ms |
+| 6.1 s | 248 ms | 260 ms | 591 ms |
+
+## End-to-end pipeline response
+
+From `test_response_latency_is_under_one_second`, which measures
+`Stats.response_ms`: the time from the speaker falling silent to the closing
+chunk becoming audible. The fake player swallows audio instantly, so this
+excludes real playback-queue wait and is a **floor**, not an estimate.
+
+| Machine | response_ms | stt_ms | tts_ms | e2e test |
+|---|---|---|---|---|
+| Intel i7-11700K | not measured | — | — | claimed to pass |
+| AMD Ryzen 7 PRO 5850U | 4240 ms | 1264 ms | 4238 ms | **fails** (asserts < 1000 ms) |
+
+The assertion is an absolute millisecond threshold, so it encodes one machine's
+performance as a correctness condition and fails on anything slower. Worth
+making relative to measured stage timings, or gating it behind a marker.
+
+## Precision variants
+
+Kokoro-82M, i7-11700K, from [ADR 4](adr/0004-speech-synthesis-model.md). Kept
+here because int8 being *slower* is the counter-intuitive result most likely to
+be re-attempted.
+
+| Weights | Size | Threads | Short (2.4 s) | RTF | Long (6.1 s) | RTF |
+|---|---|---|---|---|---|---|
+| fp32 | 326 MB | auto | 486 ms | 0.202 | 1283 ms | 0.209 |
+| fp32 | 326 MB | 8 | 462 ms | 0.192 | 1161 ms | 0.189 |
+| **fp16** | **178 MB** | **auto** | **425 ms** | **0.184** | **1157 ms** | **0.183** |
+| fp16 | 178 MB | 8 | 413 ms | 0.179 | 1094 ms | 0.173 |
+| int8 | 92 MB | 8 | 2606 ms | 1.072 | 6002 ms | 0.994 |
+
+## Open questions
+
+- **Is the 5850U gap hardware or the onnxruntime build?** An 11× synthesis gap
+  is more than a mobile part should account for on its own. Two untested
+  candidates: Rocket Lake has AVX-512, which MLAS kernels exploit heavily,
+  while Zen 3 has only AVX2; and the nixpkgs onnxruntime may be configured
+  differently from the PyPI wheel (it also advertises
+  `OpenVINOExecutionProvider`, which the wheel does not). Resolving it means
+  running `bench` against the PyPI wheel on the same machine.
+- **The i7-11700K row has never been reproduced**, and its onnxruntime version
+  was not recorded. Treat it as provenance-weak until someone re-runs it.
+- **No DirectML numbers.** `Enable-GPU.bat` benchmarks it but nobody has
+  recorded the result on the target Radeon RX 9070 XT.

--- a/docs/adr/0003-speech-recognition-model.md
+++ b/docs/adr/0003-speech-recognition-model.md
@@ -56,6 +56,9 @@ and costs accuracy headroom for a saving that only matters on disk.
   `models.STT_MODEL` gets 25 languages at a small English accuracy cost, if
   that is ever wanted.
 - ~660 MB one-time download, cached by `huggingface_hub`.
+- The timings above are this machine only. Per-machine measurements collected
+  since are in [BENCHMARKS.md](../BENCHMARKS.md), and they vary by more than an
+  order of magnitude.
 - The model is non-streaming: it transcribes a complete buffer. We get
   streaming behaviour by re-running it on a growing buffer and reconciling the
   results (ADR 5), which is affordable precisely because a pass is ~200 ms.

--- a/docs/adr/0004-speech-synthesis-model.md
+++ b/docs/adr/0004-speech-synthesis-model.md
@@ -63,6 +63,10 @@ Piper is kept as a fast, lower-quality fallback.
 - Output is 24 kHz mono, resampled to whatever the output device wants.
 - `kokoro-onnx` phonemises through espeak-ng, which brings the path-length
   problem documented in `stts/paths.py` and ADR 6.
+- RTF ~0.18 holds on this machine and cannot be assumed elsewhere: a Ryzen 7
+  PRO 5850U laptop measures ~1.75, i.e. slower than real time, which breaks the
+  overlap ADR 5 depends on. Per-machine numbers:
+  [BENCHMARKS.md](../BENCHMARKS.md).
 - RTF ~0.18 means synthesis is the dominant cost in the pipeline. Splitting
   text into sentence-sized chunks so playback overlaps generation (ADR 5) is
   what keeps that off the critical path.


### PR DESCRIPTION
Follow-up to #10. Two things: make the nix flake able to run the application, and start recording benchmark numbers per machine.

## The flake could only run pytest

Two things blocked it from starting the app:

- `tkinter` was absent, so `import stts.gui` failed with `ModuleNotFoundError: No module named '_tkinter'`.
- `kokoro-onnx` was absent, and without it there is no `Synthesiser` and therefore no output voice.

nixpkgs carries none of `kokoro-onnx`, `phonemizer-fork` or `espeakng-loader`, so the flake builds them. The first two come from their PyPI wheels — both pure Python, all transitive deps already packaged.

`espeakng-loader` is a **shim** rather than the upstream wheel. Upstream vendors a `libespeak-ng` inside a manylinux wheel, which would need `autoPatchelf`; since `stts.tts` only ever calls `get_library_path()` and `get_data_path()`, pointing those two at the `espeak-ng` nixpkgs already builds is simpler and uses a properly linked library. It carries real `dist-info` metadata so kokoro-onnx's declared dependency is genuinely satisfied rather than suppressed with `dontCheckRuntimeDeps`.

The CLI is now a `buildPythonApplication`, so `nix run` works from any directory. My first attempt wrapped `python -m stts.cli`, which only worked when the working directory happened to be the source tree.

```bash
nix run .# -- doctor / setup / bench
nix run .#            # opens the GUI
nix develop           # adds pytest and uv
nix flake check       # 57 unit tests, hermetic
```

## Benchmark table

`docs/BENCHMARKS.md`, to be filled in as more machines are tested. The ADRs record decisions; this records numbers, which accumulate rather than settle.

| Machine | AVX-512 | onnxruntime | Recognise | Synthesise | Kokoro RTF | Real-time capable |
|---|---|---|---|---|---|---|
| i7-11700K, desktop | yes | not recorded | 190 ms | 425 ms | 0.18 | yes |
| Ryzen 7 PRO 5850U, laptop | no | nixpkgs 1.27.1 | 1573 ms | 4784 ms | 1.75 | **no** |

RTF above 1.0 means synthesis is slower than speech, so the chunk overlap that ADR 5's latency budget depends on cannot happen, and `test_response_latency_is_under_one_second` fails at 4240 ms against its 1000 ms assertion.

Every row records CPU, AVX-512 presence, onnxruntime source and version, and execution provider. The i7-11700K row predates that rule and its onnxruntime version is unknown — noted rather than papered over.

## Left as open questions rather than guesses

- Whether the 11× synthesis gap is hardware (Rocket Lake's AVX-512, which MLAS exploits; Zen 3 lacks it) or the onnxruntime build (nixpkgs vs the PyPI wheel). Needs a wheel-based `bench` on the same machine.
- The e2e latency assertion is an absolute threshold, so it encodes one machine's performance as a correctness condition.
- No DirectML result has ever been recorded on the target RX 9070 XT.

## Verification

- `nix flake check` passes (57 passed, 8 skipped) and is a real gate — verified earlier with a deliberately failing canary in both `nix flake check` and `nix build`.
- With models present, the full suite runs under nix: **64 passed, 1 failed** — the failure being the hardware-dependent latency assertion above.
- espeak paths resolve with `phontab` present; `stts.gui` imports; `doctor` reports 3 microphones via PipeWire; `nix run` works from outside the checkout.
- All benchmark arithmetic recomputed from raw `bench` output; all cross-document links resolved.

No settings migration is included: nothing shipped under the old `%LOCALAPPDATA%\VoiceMask` path, so there is nothing to migrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
